### PR TITLE
remove setVisibility

### DIFF
--- a/lib/src/main/java/net/cachapa/expandablelayout/ExpandableLayout.java
+++ b/lib/src/main/java/net/cachapa/expandablelayout/ExpandableLayout.java
@@ -99,8 +99,6 @@ public class ExpandableLayout extends FrameLayout {
 
         int size = orientation == LinearLayout.HORIZONTAL ? width : height;
 
-        setVisibility(expansion == 0 && size == 0 ? GONE : VISIBLE);
-
         int expansionDelta = size - Math.round(size * expansion);
         if (parallax > 0) {
             float parallaxDelta = expansionDelta * parallax;
@@ -227,7 +225,6 @@ public class ExpandableLayout extends FrameLayout {
             state = EXPANDING;
         }
 
-        setVisibility(state == COLLAPSED ? GONE : VISIBLE);
         this.expansion = expansion;
         requestLayout();
 


### PR DESCRIPTION
Hi, Thanks for the great library.



I think `setVisibility` is redundant.

In the case where `setVisibility(GONE)` is called, the height or width has already become 0 and it is already invisible.

And It is not preferable to call it every time in terms of performance.

Best,