### PR TITLE
Remove assignment to parameter variable

### DIFF
--- a/lib/src/main/java/net/cachapa/expandablelayout/ExpandableLayout.java
+++ b/lib/src/main/java/net/cachapa/expandablelayout/ExpandableLayout.java
@@ -242,8 +242,7 @@ public class ExpandableLayout extends FrameLayout {
 
     public void setParallax(float parallax) {
         // Make sure parallax is between 0 and 1
-        parallax = Math.min(1, Math.max(0, parallax));
-        this.parallax = parallax;
+        this.parallax = Math.min(1, Math.max(0, parallax));
     }
 
     public int getOrientation() {


### PR DESCRIPTION
Assignment to variable unnecessary since in the next line it sets the value to the member property